### PR TITLE
[libresourceqt] Specify dependencies in pkgconfig files.

### DIFF
--- a/libresourceqt/libresourceqt1.pc
+++ b/libresourceqt/libresourceqt1.pc
@@ -8,4 +8,4 @@ Description: Maemo resource management Qt API
 Version: 1.26
 Libs: -L${libdir} -lresourceqt
 Cflags: -I${includedir}
-Requires: dbus-1 libdbus-qeventloop1 libresource
+Requires: dbus-1 libdbus-qeventloop1 libresource QtCore

--- a/libresourceqt/libresourceqt5.pc
+++ b/libresourceqt/libresourceqt5.pc
@@ -8,4 +8,4 @@ Description: Maemo resource management Qt API
 Version: 1.26
 Libs: -L${libdir} -lresourceqt5
 Cflags: -I${includedir}
-Requires: dbus-1 libdbus-qeventloop5 libresource
+Requires: dbus-1 libdbus-qeventloop5 libresource Qt5Core


### PR DESCRIPTION
Relying on clients linking in our requirements is a bad, bad idea.
