### PR TITLE
[libresourceqt] Fix timer errors when library is loaded from a thread.

### DIFF
--- a/libdbus-qeventloop/dbusconnectioneventloop.cpp
+++ b/libdbus-qeventloop/dbusconnectioneventloop.cpp
@@ -26,16 +26,16 @@ USA.
 
 #include "dbusconnectioneventloop.h"
 
-DBUSConnectionEventLoop DBUSConnectionEventLoop::classInstance;
+Q_GLOBAL_STATIC(DBUSConnectionEventLoop, classInstance);
 
 bool DBUSConnectionEventLoop::addConnection(DBusConnection* conn)
 {
-    return classInstance.internalAddConnection(conn);
+    return classInstance()->internalAddConnection(conn);
 }
 
 void DBUSConnectionEventLoop::removeConnection(DBusConnection* conn)
 {
-    classInstance.internalRemoveConnection(conn);
+    classInstance()->internalRemoveConnection(conn);
 }
 
 DBUSConnectionEventLoop::DBUSConnectionEventLoop() : QObject()

--- a/libdbus-qeventloop/dbusconnectioneventloop.h
+++ b/libdbus-qeventloop/dbusconnectioneventloop.h
@@ -69,12 +69,10 @@ class DBUSConnectionEventLoop : public QObject
 {
     Q_OBJECT
 private:
-    static DBUSConnectionEventLoop classInstance;
-
     Q_DISABLE_COPY(DBUSConnectionEventLoop)
-    DBUSConnectionEventLoop();
 
 public:
+    DBUSConnectionEventLoop();
     virtual ~DBUSConnectionEventLoop();
 
     /**
@@ -83,10 +81,6 @@ public:
      */
     static bool addConnection(DBusConnection* conn);
     static void removeConnection(DBusConnection* conn);
-
-    static DBUSConnectionEventLoop &getInstance(void) {
-      return classInstance;
-    }
 
 private:
     bool internalAddConnection(DBusConnection* conn);


### PR DESCRIPTION
Make the DBUSConnectionEventLoop instance a QGlobalStatic so it is
instanciated on demand in the calling thread rather than in the thread
which the library was loaded from.
